### PR TITLE
Implement completable methods

### DIFF
--- a/pkg/trino/datasource.go
+++ b/pkg/trino/datasource.go
@@ -77,16 +77,56 @@ func (s *TrinoDatasource) Converters() (sc []sqlutil.Converter) {
 }
 
 func (s *TrinoDatasource) Schemas(ctx context.Context, options sqlds.Options) ([]string, error) {
-	// TBD
-	return []string{}, nil
+	query := "SHOW SCHEMAS"
+	args := []string{}
+	if options["database"] != "" {
+		query += " FOR ?"
+		args = append(args, options["database"])
+	}
+	rows, err := s.db.Query(query, args)
+	if err != nil {
+		return nil, err
+	}
+	return getNames(rows)
 }
 
 func (s *TrinoDatasource) Tables(ctx context.Context, options sqlds.Options) ([]string, error) {
-	// TBD
-	return []string{}, nil
+	query := "SHOW TABLES"
+	args := []string{}
+	if options["schema"] != "" {
+		query += " FOR ?"
+		args = append(args, options["schema"])
+	}
+	rows, err := s.db.Query(query, args)
+	if err != nil {
+		return nil, err
+	}
+	return getNames(rows)
 }
 
 func (s *TrinoDatasource) Columns(ctx context.Context, options sqlds.Options) ([]string, error) {
-	// TBD
-	return []string{}, nil
+	query := "SHOW COLUMNS"
+	args := []string{}
+	if options["table"] != "" {
+		query += " FOR ?"
+		args = append(args, options["table"])
+	}
+	rows, err := s.db.Query(query, args)
+	if err != nil {
+		return nil, err
+	}
+	return getNames(rows)
+}
+
+func getNames(rows *sql.Rows) ([]string, error) {
+	results := []string{}
+	name := ""
+	for rows.Next() {
+		err := rows.Scan(&name)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, name)
+	}
+	return results, nil
 }


### PR DESCRIPTION
This implements the methods of the completable interface, but I couldn't test this. It seems that it's only used with a query builder in Grafana, not with the free-query mode like we have right now. I'll keep this open as a intro to enabling the query builder.