### PR TITLE
Run tests for 2 Grafana versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,16 @@ jobs:
             --env "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=trino-datasource" \
             grafana/grafana:${{ matrix.grafana }}
 
+          echo "Waiting for Grafana to be ready..."
+          while true; do
+            if curl -s http://localhost:3000/api/health | grep -q "ok"; then
+              echo "Grafana is ready!"
+              break
+            fi
+            echo "Waiting for Grafana..."
+            sleep 5
+          done
+
       - name: End to end test
         run: |
           npx tsc -p tsconfig.json --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - test-old-grafana
   pull_request:
     branches:
       - main
+      - test-old-grafana
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,21 @@ jobs:
             grafana/grafana:${{ matrix.grafana }}
 
           echo "Waiting for Grafana to be ready..."
+          TIMEOUT=120
+          ELAPSED=0
           while true; do
             if curl -s http://localhost:3000/api/health | grep -q "ok"; then
               echo "Grafana is ready!"
               break
             fi
-            echo "Waiting for Grafana..."
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for Grafana to be ready"
+              docker logs grafana
+              exit 1
+            fi
+            echo "Waiting for Grafana... ($ELAPSED/$TIMEOUT seconds)"
             sleep 5
+            ELAPSED=$((ELAPSED + 5))
           done
 
       - name: End to end test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,29 @@ jobs:
             --name trino \
             --net trino \
             --volume "$(pwd)/test-data/test-trino-config.properties:/etc/trino/config.properties" \
+            --volume "$(pwd)/test-data/tpch.properties:/etc/trino/catalog/tpch.properties" \
             trinodb/trino:468
+
+          echo "Waiting for Trino to be ready..."
+          TIMEOUT=120
+          ELAPSED=0
+          while true; do
+            if docker exec trino trino --execute "SELECT 1" &>/dev/null; then
+              echo "Trino is ready!"
+              break
+            fi
+            if [ $ELAPSED -ge $TIMEOUT ]; then
+              echo "Timeout waiting for Trino to be ready"
+              docker logs trino
+              exit 1
+            fi
+            echo "Waiting for Trino... ($ELAPSED/$TIMEOUT seconds)"
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+
+          echo "Verifying TPCH catalog is available..."
+          docker exec trino trino --execute "SHOW CATALOGS" || echo "Warning: Could not verify catalogs"
 
           echo "Starting Grafana..."
           docker run --rm --detach \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
           done
 
       - name: End to end test
+        env:
+          GRAFANA_VERSION: ${{ matrix.grafana }}
         run: |
           npx tsc -p tsconfig.json --noEmit
           npx playwright install

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
+  timeout: process.env.CI ? 60000 : 30000,
   reporter: 'html',
   use: {
     baseURL: 'http://127.0.0.1:3000',

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -23,6 +23,7 @@ async function setupDataSourceWithAccessToken(page: Page) {
     await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await page.getByLabel('Data source settings page Save and Test button').click();
+    await page.waitForTimeout(2000); // Wait for save operation to complete
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
@@ -32,6 +33,7 @@ async function setupDataSourceWithClientCredentials(page: Page, clientId: string
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
     await page.getByLabel('Data source settings page Save and Test button').click();
+    await page.waitForTimeout(2000); // Wait for save operation to complete
 }
 
 async function runQueryAndCheckResults(page: Page) {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -23,7 +23,8 @@ async function setupDataSourceWithAccessToken(page: Page) {
     await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await page.getByLabel('Data source settings page Save and Test button').click();
-    await page.waitForTimeout(2000); // Wait for save operation to complete
+    // Wait for either success or error message to appear
+    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 5000 });
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
@@ -33,7 +34,8 @@ async function setupDataSourceWithClientCredentials(page: Page, clientId: string
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
     await page.getByLabel('Data source settings page Save and Test button').click();
-    await page.waitForTimeout(2000); // Wait for save operation to complete
+    // Wait for either success or error message to appear
+    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 5000 });
 }
 
 async function runQueryAndCheckResults(page: Page) {
@@ -66,7 +68,19 @@ test('test client credentials flow with wrong credentials', async ({ page }) => 
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithClientCredentials(page, "some-wrong-client");
-    await expect(page.getByText(EXPLORE_DATA)).toHaveCount(0);
+    // Check for error alert instead of checking absence of Explore button
+    // The data source might still be saved even with wrong credentials
+    // So we check if there's an error message or the Explore button is disabled/not present
+    const exploreButton = page.getByText(EXPLORE_DATA);
+    const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
+    
+    // Either there should be an error alert, or the Explore button should not be visible
+    const hasError = await errorAlert.count() > 0;
+    
+    // If there's no error alert, then Explore button should not be present
+    if (!hasError) {
+        await expect(exploreButton).toHaveCount(0);
+    }
 });
 
 test('test client credentials flow with configured access token', async ({ page }) => {
@@ -74,5 +88,16 @@ test('test client credentials flow with configured access token', async ({ page 
     await goToTrinoSettings(page);
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
-    await expect(page.getByText(EXPLORE_DATA)).toHaveCount(0);
+    // Check for error alert instead of checking absence of Explore button
+    // Setting both access token and client credentials should be invalid
+    const exploreButton = page.getByText(EXPLORE_DATA);
+    const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
+    
+    // Either there should be an error alert, or the Explore button should not be visible
+    const hasError = await errorAlert.count() > 0;
+    
+    // If there's no error alert, then Explore button should not be present
+    if (!hasError) {
+        await expect(exploreButton).toHaveCount(0);
+    }
 });

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,61 +1,79 @@
 import { test, expect, Page, Locator } from '@playwright/test';
 
 const GRAFANA_CLIENT = 'grafana-client';
+const GRAFANA_VERSION = process.env.GRAFANA_VERSION || '9.5.0';
+const GRAFANA_MAJOR = parseInt(GRAFANA_VERSION.split('.')[0], 10);
+const isNewGrafana = GRAFANA_MAJOR >= 10;
 
-// Helper: resolves across Grafana 9.x (aria-label) and 11.x (data-testid)
-function byLabelOrTestId(page: Page, label: string): Locator {
-    return page.getByLabel(label).or(page.getByTestId(`data-testid ${label}`));
+// Grafana 9.x uses aria-label, 10+ uses data-testid
+function sel(page: Page, name: string): Locator {
+    return isNewGrafana
+        ? page.getByTestId(`data-testid ${name}`)
+        : page.getByLabel(name);
 }
 
 async function login(page: Page) {
     await page.goto('http://localhost:3000/login');
-    await byLabelOrTestId(page, 'Username input field').fill('admin');
-    await byLabelOrTestId(page, 'Password input field').fill('admin');
-    await byLabelOrTestId(page, 'Login button').click();
-    await byLabelOrTestId(page, 'Skip change password button').click();
+    await sel(page, 'Username input field').fill('admin');
+    await sel(page, 'Password input field').fill('admin');
+    await sel(page, 'Login button').click();
+    await sel(page, 'Skip change password button').click();
+    await page.waitForLoadState('networkidle');
 }
 
 async function goToTrinoSettings(page: Page) {
-    await byLabelOrTestId(page, 'Toggle menu').click();
+    await sel(page, 'Toggle menu').click();
     await page.getByRole('link', {name: 'Connections'}).click();
     await page.getByRole('link', {name: 'Trino'}).click();
-    // Grafana 9.x: "Create a Trino data source"; 11.x: "Add new data source"
-    await page.getByText('Create a Trino data source')
-        .or(page.getByRole('button', {name: 'Add new data source'}))
-        .click();
+    if (isNewGrafana) {
+        await page.getByRole('button', {name: 'Add new data source'}).click();
+    } else {
+        await page.getByText('Create a Trino data source').click();
+    }
 }
 
 async function setupDataSourceWithAccessToken(page: Page) {
-    await byLabelOrTestId(page, 'Datasource HTTP settings url').fill('http://trino:8080');
-    // 9.x: div text is "Impersonate logged in userAccess token"; 11.x: "Impersonate logged in user"
-    await page.locator('div').filter({hasText: /^Impersonate logged in user(Access token)?$/}).getByLabel('Toggle switch').click();
+    await sel(page, 'Datasource HTTP settings url').fill('http://trino:8080');
+    if (isNewGrafana) {
+        await page.locator('div').filter({hasText: /^Impersonate logged in user$/}).getByLabel('Toggle switch').click();
+    } else {
+        await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
+    }
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
-    await byLabelOrTestId(page, 'Data source settings page Save and Test button').click();
-    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 10000 });
+    await sel(page, 'Data source settings page Save and Test button').click();
+    await page.waitForSelector('[role="alert"]', { timeout: 10000 });
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
-    await byLabelOrTestId(page, 'Datasource HTTP settings url').fill('http://trino:8080');
+    await sel(page, 'Datasource HTTP settings url').fill('http://trino:8080');
     await page.locator('div').filter({hasText: /^Token URL$/}).locator('input').fill('http://keycloak:8080/realms/trino-realm/protocol/openid-connect/token');
     await page.locator('div').filter({hasText: /^Client id$/}).locator('input').fill(clientId);
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
-    await byLabelOrTestId(page, 'Data source settings page Save and Test button').click();
-    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 10000 });
+    await sel(page, 'Data source settings page Save and Test button').click();
+    await page.waitForSelector('[role="alert"]', { timeout: 10000 });
 }
 
 async function runQueryAndCheckResults(page: Page) {
-    // "Explore" text in 9.x, "Explore data" label in 11.x
-    await page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data')).click();
+    if (isNewGrafana) {
+        await page.getByLabel('Explore data').click();
+    } else {
+        await page.getByText('Explore', {exact: true}).click();
+    }
     await page.getByTestId('data-testid TimePicker Open Button').click();
-    await byLabelOrTestId(page, 'Time Range from field').fill('1995-01-01');
-    await byLabelOrTestId(page, 'Time Range to field').fill('1995-12-31');
+    await sel(page, 'Time Range from field').fill('1995-01-01');
+    await sel(page, 'Time Range to field').fill('1995-12-31');
     await page.getByTestId('data-testid TimePicker submit button').click();
-    // Format dropdown: use combobox role (works in both 9.x and 11.x)
-    await page.getByRole('combobox', { name: 'Format as' }).click();
-    await page.getByText('Table', { exact: true }).or(page.getByRole('option', {name: 'Table'})).click();
+    if (isNewGrafana) {
+        await page.locator('div').filter({hasText: /^Format asChoose$/}).locator('svg').click();
+        await page.getByRole('option', {name: 'Table'}).click();
+        await page.getByTestId('data-testid Code editor container').click();
+    } else {
+        await page.getByRole('combobox', { name: 'Format as' }).click();
+        await page.getByRole('option', {name: 'Table'}).click();
+    }
     await page.getByTestId('data-testid RefreshPicker run button').click();
-    await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:00.*/);
+    await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:00.*/, { timeout: 30000 });
 }
 
 test('test with access token', async ({ page }) => {
@@ -76,9 +94,10 @@ test('test client credentials flow with wrong credentials', async ({ page }) => 
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithClientCredentials(page, "some-wrong-client");
-    // After Save & Test with wrong credentials, an error alert should appear
-    const errorAlert = page.locator('[role="alert"]').filter({ hasText: /error|failed|Error/i });
-    await expect(errorAlert.first()).toBeVisible({ timeout: 10000 });
+    // Alert is already visible (setupDataSourceWithClientCredentials waits for it).
+    // Verify it is NOT the success message.
+    await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="alert"]').filter({ hasText: 'Data source is working' })).toHaveCount(0);
 });
 
 test('test client credentials flow with configured access token', async ({ page }) => {
@@ -86,7 +105,8 @@ test('test client credentials flow with configured access token', async ({ page 
     await goToTrinoSettings(page);
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
-    // After Save & Test with both access token and client credentials, an error alert should appear
-    const errorAlert = page.locator('[role="alert"]').filter({ hasText: /error|failed|Error/i });
-    await expect(errorAlert.first()).toBeVisible({ timeout: 10000 });
+    // Alert is already visible (setupDataSourceWithClientCredentials waits for it).
+    // Verify it is NOT the success message.
+    await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[role="alert"]').filter({ hasText: 'Data source is working' })).toHaveCount(0);
 });

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,51 +1,59 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, Locator } from '@playwright/test';
 
 const GRAFANA_CLIENT = 'grafana-client';
-const EXPLORE_DATA = 'Explore';
+
+// Helper: resolves across Grafana 9.x (aria-label) and 11.x (data-testid)
+function byLabelOrTestId(page: Page, label: string): Locator {
+    return page.getByLabel(label).or(page.getByTestId(`data-testid ${label}`));
+}
 
 async function login(page: Page) {
     await page.goto('http://localhost:3000/login');
-    await page.getByLabel('Username input field').fill('admin');
-    await page.getByLabel('Password input field').fill('admin');
-    await page.getByLabel('Login button').click();
-    await page.getByLabel('Skip change password button').click();
+    await byLabelOrTestId(page, 'Username input field').fill('admin');
+    await byLabelOrTestId(page, 'Password input field').fill('admin');
+    await byLabelOrTestId(page, 'Login button').click();
+    await byLabelOrTestId(page, 'Skip change password button').click();
 }
 
 async function goToTrinoSettings(page: Page) {
-    await page.getByLabel('Toggle menu').click();
+    await byLabelOrTestId(page, 'Toggle menu').click();
     await page.getByRole('link', {name: 'Connections'}).click();
     await page.getByRole('link', {name: 'Trino'}).click();
-    await page.getByText('Create a Trino data source').click();
+    // Grafana 9.x: "Create a Trino data source"; 11.x: "Add new data source"
+    await page.getByText('Create a Trino data source')
+        .or(page.getByRole('button', {name: 'Add new data source'}))
+        .click();
 }
 
 async function setupDataSourceWithAccessToken(page: Page) {
-    await page.getByLabel('Datasource HTTP settings url').fill('http://trino:8080');
-    await page.locator('div').filter({hasText: /^Impersonate logged in userAccess token$/}).getByLabel('Toggle switch').click();
+    await byLabelOrTestId(page, 'Datasource HTTP settings url').fill('http://trino:8080');
+    // 9.x: div text is "Impersonate logged in userAccess token"; 11.x: "Impersonate logged in user"
+    await page.locator('div').filter({hasText: /^Impersonate logged in user(Access token)?$/}).getByLabel('Toggle switch').click();
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
-    await page.getByLabel('Data source settings page Save and Test button').click();
-    // Wait for either success or error message to appear
-    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 5000 });
+    await byLabelOrTestId(page, 'Data source settings page Save and Test button').click();
+    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 10000 });
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
-    await page.getByLabel('Datasource HTTP settings url').fill('http://trino:8080');
+    await byLabelOrTestId(page, 'Datasource HTTP settings url').fill('http://trino:8080');
     await page.locator('div').filter({hasText: /^Token URL$/}).locator('input').fill('http://keycloak:8080/realms/trino-realm/protocol/openid-connect/token');
     await page.locator('div').filter({hasText: /^Client id$/}).locator('input').fill(clientId);
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
-    await page.getByLabel('Data source settings page Save and Test button').click();
-    // Wait for either success or error message to appear
-    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 5000 });
+    await byLabelOrTestId(page, 'Data source settings page Save and Test button').click();
+    await page.waitForSelector('[role="alert"], [data-testid="data-testid Alert success"]', { timeout: 10000 });
 }
 
 async function runQueryAndCheckResults(page: Page) {
-    await page.getByText(EXPLORE_DATA).click();
+    // "Explore" text in 9.x, "Explore data" label in 11.x
+    await page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data')).click();
     await page.getByTestId('data-testid TimePicker Open Button').click();
-    await page.getByLabel('Time Range from field').fill('1995-01-01');
-    await page.getByLabel('Time Range to field').fill('1995-12-31');
+    await byLabelOrTestId(page, 'Time Range from field').fill('1995-01-01');
+    await byLabelOrTestId(page, 'Time Range to field').fill('1995-12-31');
     await page.getByTestId('data-testid TimePicker submit button').click();
-    await page.getByLabel('Format as').click();
-    await page.getByText('Table', { exact: true }).click();
+    // Format dropdown: aria-label in 9.x, div structure in 11.x
+    await page.getByLabel('Format as').or(page.locator('div').filter({hasText: /^Format as/}).locator('svg')).click();
+    await page.getByText('Table', { exact: true }).or(page.getByRole('option', {name: 'Table'})).click();
     await page.getByTestId('data-testid RefreshPicker run button').click();
     await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:00.*/);
 }
@@ -71,7 +79,7 @@ test('test client credentials flow with wrong credentials', async ({ page }) => 
     // Check for error alert instead of checking absence of Explore button
     // The data source might still be saved even with wrong credentials
     // So we check if there's an error message or the Explore button is disabled/not present
-    const exploreButton = page.getByText(EXPLORE_DATA);
+    const exploreButton = page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data'));
     const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
     
     // Either there should be an error alert, or the Explore button should not be visible
@@ -90,7 +98,7 @@ test('test client credentials flow with configured access token', async ({ page 
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
     // Check for error alert instead of checking absence of Explore button
     // Setting both access token and client credentials should be invalid
-    const exploreButton = page.getByText(EXPLORE_DATA);
+    const exploreButton = page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data'));
     const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
     
     // Either there should be an error alert, or the Explore button should not be visible

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -18,7 +18,6 @@ async function login(page: Page) {
     await sel(page, 'Password input field').fill('admin');
     await sel(page, 'Login button').click();
     await sel(page, 'Skip change password button').click();
-    await page.waitForLoadState('networkidle');
 }
 
 async function goToTrinoSettings(page: Page) {
@@ -32,6 +31,15 @@ async function goToTrinoSettings(page: Page) {
     }
 }
 
+// Wait for Save & Test response: "Data source is working" or any error text
+async function waitForSaveTestResult(page: Page): Promise<boolean> {
+    const success = page.getByText('Data source is working');
+    const error = page.getByText('Data source is not working');
+    // Wait for either success or failure message
+    await success.or(error).waitFor({ timeout: 30000 });
+    return await success.isVisible();
+}
+
 async function setupDataSourceWithAccessToken(page: Page) {
     await sel(page, 'Datasource HTTP settings url').fill('http://trino:8080');
     if (isNewGrafana) {
@@ -41,7 +49,6 @@ async function setupDataSourceWithAccessToken(page: Page) {
     }
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await sel(page, 'Data source settings page Save and Test button').click();
-    await page.waitForSelector('[role="alert"]', { timeout: 10000 });
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
@@ -51,7 +58,6 @@ async function setupDataSourceWithClientCredentials(page: Page, clientId: string
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
     await sel(page, 'Data source settings page Save and Test button').click();
-    await page.waitForSelector('[role="alert"]', { timeout: 10000 });
 }
 
 async function runQueryAndCheckResults(page: Page) {
@@ -80,6 +86,8 @@ test('test with access token', async ({ page }) => {
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithAccessToken(page);
+    const ok = await waitForSaveTestResult(page);
+    expect(ok).toBe(true);
     await runQueryAndCheckResults(page);
 });
 
@@ -87,6 +95,8 @@ test('test client credentials flow', async ({ page }) => {
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
+    const ok = await waitForSaveTestResult(page);
+    expect(ok).toBe(true);
     await runQueryAndCheckResults(page);
 });
 
@@ -94,10 +104,8 @@ test('test client credentials flow with wrong credentials', async ({ page }) => 
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithClientCredentials(page, "some-wrong-client");
-    // Alert is already visible (setupDataSourceWithClientCredentials waits for it).
-    // Verify it is NOT the success message.
-    await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('[role="alert"]').filter({ hasText: 'Data source is working' })).toHaveCount(0);
+    const ok = await waitForSaveTestResult(page);
+    expect(ok).toBe(false);
 });
 
 test('test client credentials flow with configured access token', async ({ page }) => {
@@ -105,8 +113,6 @@ test('test client credentials flow with configured access token', async ({ page 
     await goToTrinoSettings(page);
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
-    // Alert is already visible (setupDataSourceWithClientCredentials waits for it).
-    // Verify it is NOT the success message.
-    await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('[role="alert"]').filter({ hasText: 'Data source is working' })).toHaveCount(0);
+    const ok = await waitForSaveTestResult(page);
+    expect(ok).toBe(false);
 });

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -51,8 +51,8 @@ async function runQueryAndCheckResults(page: Page) {
     await byLabelOrTestId(page, 'Time Range from field').fill('1995-01-01');
     await byLabelOrTestId(page, 'Time Range to field').fill('1995-12-31');
     await page.getByTestId('data-testid TimePicker submit button').click();
-    // Format dropdown: aria-label in 9.x, div structure in 11.x
-    await page.getByLabel('Format as').or(page.locator('div').filter({hasText: /^Format as/}).locator('svg')).click();
+    // Format dropdown: use combobox role (works in both 9.x and 11.x)
+    await page.getByRole('combobox', { name: 'Format as' }).click();
     await page.getByText('Table', { exact: true }).or(page.getByRole('option', {name: 'Table'})).click();
     await page.getByTestId('data-testid RefreshPicker run button').click();
     await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:00.*/);
@@ -76,19 +76,9 @@ test('test client credentials flow with wrong credentials', async ({ page }) => 
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithClientCredentials(page, "some-wrong-client");
-    // Check for error alert instead of checking absence of Explore button
-    // The data source might still be saved even with wrong credentials
-    // So we check if there's an error message or the Explore button is disabled/not present
-    const exploreButton = page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data'));
-    const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
-    
-    // Either there should be an error alert, or the Explore button should not be visible
-    const hasError = await errorAlert.count() > 0;
-    
-    // If there's no error alert, then Explore button should not be present
-    if (!hasError) {
-        await expect(exploreButton).toHaveCount(0);
-    }
+    // After Save & Test with wrong credentials, an error alert should appear
+    const errorAlert = page.locator('[role="alert"]').filter({ hasText: /error|failed|Error/i });
+    await expect(errorAlert.first()).toBeVisible({ timeout: 10000 });
 });
 
 test('test client credentials flow with configured access token', async ({ page }) => {
@@ -96,16 +86,7 @@ test('test client credentials flow with configured access token', async ({ page 
     await goToTrinoSettings(page);
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
-    // Check for error alert instead of checking absence of Explore button
-    // Setting both access token and client credentials should be invalid
-    const exploreButton = page.getByText('Explore', {exact: true}).or(page.getByLabel('Explore data'));
-    const errorAlert = page.locator('[role="alert"]:has-text("error"), [role="alert"]:has-text("failed"), [role="alert"]:has-text("Error")');
-    
-    // Either there should be an error alert, or the Explore button should not be visible
-    const hasError = await errorAlert.count() > 0;
-    
-    // If there's no error alert, then Explore button should not be present
-    if (!hasError) {
-        await expect(exploreButton).toHaveCount(0);
-    }
+    // After Save & Test with both access token and client credentials, an error alert should appear
+    const errorAlert = page.locator('[role="alert"]').filter({ hasText: /error|failed|Error/i });
+    await expect(errorAlert.first()).toBeVisible({ timeout: 10000 });
 });

--- a/test-data/tpch.properties
+++ b/test-data/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch


### PR DESCRIPTION
## Summary by Sourcery

Run end-to-end tests against two Grafana versions in CI and ensure Grafana is fully ready before testing

Enhancements:
- Add a polling loop in the CI workflow to wait for Grafana's /api/health endpoint to report “ok” before running tests

CI:
- Expand the CI matrix to test against two Grafana versions