### PR TITLE
Make e2e generic to work on old and new grafana version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        grafana: ['9.5.0', '11.6.1']
     steps:
       - uses: actions/checkout@v4
 
@@ -43,19 +47,10 @@ jobs:
           version: latest
           args: buildAll
 
-      - name: Setup services (Trino, Grafana, PostgreSQL, Keycloak)
+      - name: Setup services (Trino, Grafana, Keycloak)
         run: |
           docker network create trino
 
-          echo "Starting PostgreSQL..."
-          docker run --rm --detach \
-            --name postgres \
-            --net trino \
-            --env POSTGRES_USER=keycloak \
-            --env POSTGRES_PASSWORD=keycloak \
-            --env POSTGRES_DB=keycloak \
-            postgres:17.4
-          
           echo "Starting Keycloak..."
           docker run --rm --detach \
             --name keycloak \
@@ -63,11 +58,6 @@ jobs:
             --publish 18080:8080 \
             --env KC_BOOTSTRAP_ADMIN_USERNAME=admin \
             --env KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
-            --env KC_DB=postgres \
-            --env KC_DB_URL_HOST=postgres \
-            --env KC_DB_URL_DATABASE=keycloak \
-            --env KC_DB_USERNAME=keycloak \
-            --env KC_DB_PASSWORD=keycloak \
             --volume "$(pwd)/test-data/test-keycloak-realm.json:/opt/keycloak/data/import/realm.json" \
             quay.io/keycloak/keycloak:26.1.4 \
             start-dev --import-realm
@@ -97,7 +87,7 @@ jobs:
             --publish 3000:3000 \
             --volume "$(pwd):/var/lib/grafana/plugins/trino" \
             --env "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=trino-datasource" \
-            grafana/grafana:11.4.0
+            grafana/grafana:${{ matrix.grafana }}
           
           echo "Waiting for Trino to be ready..."
           while true; do
@@ -108,7 +98,7 @@ jobs:
             echo "Waiting for Trino..."
             sleep 5
           done
-
+          
           echo "Preconfiguring trino..."
           docker exec trino trino --user admin --execute "GRANT admin TO USER grafana IN hive;"
           echo "Done."
@@ -118,3 +108,25 @@ jobs:
           npx tsc -p tsconfig.json --noEmit
           npx playwright install
           npx playwright test
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.grafana }}
+          path: playwright-report/
+          retention-days: 5
+
+      - name: Dump logs
+        if: always()
+        run: |
+          echo "::group::Trino logs"
+          docker logs trino
+          echo "::endgroup::"
+
+          echo "::group::Keycloak logs"
+          docker logs keycloak
+          echo "::endgroup::"
+
+          echo "::group::Grafana logs"
+          docker logs grafana
+          echo "::endgroup::"

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,60 +1,90 @@
 import { test, expect, Page } from '@playwright/test';
 
 const GRAFANA_CLIENT = 'grafana-client';
-const EXPORT_DATA = 'Explore data';
+const EXPLORE_DATA = 'Explore';
 
 async function login(page: Page) {
     await page.goto('http://localhost:3000/login');
-    await page.getByTestId('data-testid Username input field').fill('admin');
-    await page.getByTestId('data-testid Password input field').fill('admin');
-    await page.getByTestId('data-testid Login button').click();
-    await page.getByTestId('data-testid Skip change password button').click();
+    await page.getByPlaceholder('email or username').fill('admin');
+    await page.getByPlaceholder('password').fill('admin');
+    await page.getByRole('button', { name: 'Login button' }).or(page.getByRole('button', { name: 'Log in' })).click();
+    await page.getByRole('button', { name: /skip/i }).click();
 }
 
 async function goToTrinoSettings(page: Page) {
-    await page.getByTestId('data-testid Toggle menu').click();
-    await page.getByRole('link', {name: 'Connections'}).click();
-    await page.getByRole('link', {name: 'Trino'}).click();
-    await page.locator('.css-1yhi3xa').click();
-    await page.getByRole('button', {name: 'Add new data source'}).click();
+    await page.getByRole('button', { name: /toggle menu|open menu/i }).click();
+    await page.getByText('Connections').click();
+    await page.getByText(/add.*connection|connect data/i).first().click();
+    await page.getByText('Trino').click();
+    await page.getByRole('button', { name: /add new data source|create.*trino.*data source/i }).click();
 }
 
 async function setupDataSourceWithAccessToken(page: Page) {
-    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
-    await page.locator('div').filter({hasText: /^Impersonate logged in user$/}).getByLabel('Toggle switch').click();
+    await page.getByPlaceholder('http://localhost:8080').fill('http://trino:8080');
+    await page.locator('label[for="trino-settings-enable-impersonation"][aria-label="Toggle switch"], label[for="trino-settings-enable-impersonation"]:has(svg)').first().click();
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
-    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+    await page.getByRole('button', { name: /save.*test/i }).click();
 }
 
 async function setupDataSourceWithClientCredentials(page: Page, clientId: string) {
-    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
+    await page.getByPlaceholder('http://localhost:8080').fill('http://trino:8080');
     await page.locator('div').filter({hasText: /^Token URL$/}).locator('input').fill('http://keycloak:8080/realms/trino-realm/protocol/openid-connect/token');
     await page.locator('div').filter({hasText: /^Client id$/}).locator('input').fill(clientId);
     await page.locator('div').filter({hasText: /^Client secret$/}).locator('input[type="password"]').fill('grafana-secret');
     await page.locator('div').filter({hasText: /^Impersonation user$/}).locator('input').fill('service-account-grafana-client');
-    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
-}
-
-async function setupDataSourceWithClientTags(page: Page, clientTags: string) {
-    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
-    await page.locator('div').filter({hasText: /^Impersonate logged in user$/}).getByLabel('Toggle switch').click();
-    await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
-    await page.locator('div').filter({hasText: /^Client Tags$/}).locator('input').fill(clientTags);
-    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+    await page.getByRole('button', { name: /save.*test/i }).click();
 }
 
 async function runQueryAndCheckResults(page: Page) {
-    await page.getByLabel(EXPORT_DATA).click();
+    await page.getByText(EXPLORE_DATA).click();
+    await page.locator('textarea[aria-label*="Editor content"]').click();
     await page.getByTestId('data-testid TimePicker Open Button').click();
-    await page.getByTestId('data-testid Time Range from field').fill('1995-01-01');
-    await page.getByTestId('data-testid Time Range to field').fill('1995-12-31');
+    const timeInputs = page.locator('input[value*="now"], input[value*="00:00:00"]');
+    await timeInputs.first().fill('1995-01-01');
+    await timeInputs.last().fill('1995-12-31');
     await page.getByTestId('data-testid TimePicker submit button').click();
-    await page.locator('div').filter({hasText: /^Format asChoose$/}).locator('svg').click();
-    await page.getByRole('option', {name: 'Table'}).click();
-    await page.getByTestId('data-testid Code editor container').click();
-    await page.getByTestId('data-testid RefreshPicker run button').click();
-    await expect(page.getByTestId('data-testid table body')).toContainText(/.*1995-01-19 0.:00:005703857F.*/);
+    await page.locator('[role="combobox"][aria-label="Format as"]').click();
+    await page.locator('[id^="react-select"][id$="option-1"]').waitFor();
+    await page.locator('[id^="react-select"][id$="option-1"]').click();
+    await expect(page.locator('[role="table"][aria-label="Explore Table"]').getByText(/1995-01-\d+/).first()).toBeVisible();
 }
+
+async function setupDataSourceWithClientTags(page: Page, clientTags: string) {
+    await page.getByPlaceholder('http://localhost:8080').fill('http://trino:8080');
+    await page.locator('label[for="trino-settings-enable-impersonation"][aria-label="Toggle switch"], label[for="trino-settings-enable-impersonation"]:has(svg)').first().click();
+    await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
+    await page.locator('div').filter({hasText: /^Client Tags$/}).locator('input').fill(clientTags);
+    await page.getByRole('button', { name: /save.*test/i }).click();
+}
+
+async function setupDataSourceWithRoles(page: Page, roles: string) {
+    await page.getByPlaceholder('http://localhost:8080').fill('http://trino:8080');
+    await page.locator('div').filter({hasText: /^Roles$/}).locator('input').fill(roles);
+    await page.getByRole('button', { name: /save.*test/i }).click();
+}
+
+async function runRoleQuery(page: Page) {
+    await page.getByText(EXPLORE_DATA).click();
+    await setQuery(page, 'SHOW ROLES FROM hive')
+    await page.locator('[role="combobox"][aria-label="Format as"]').click();
+    await page.locator('[id^="react-select"][id$="option-1"]').waitFor();
+    await page.locator('[id^="react-select"][id$="option-1"]').click();
+
+}
+
+async function setQuery(page: Page, query: string) {
+    await page.locator('textarea[aria-label*="Editor content"]').click();
+    await page.keyboard.press('Control+a');
+    await page.keyboard.type(query);
+}
+
+test('test client credentials flow with wrong credentials', async ({ page }) => {
+    await login(page);
+    await goToTrinoSettings(page);
+    await setupDataSourceWithClientCredentials(page, "some-wrong-client");
+    await expect(page.getByTestId('data-testid Alert error')).toBeVisible();
+    await expect(page.getByTestId('data-testid Alert error')).toContainText('Bad Request');
+});
 
 test('test with access token', async ({ page }) => {
     await login(page);
@@ -70,19 +100,13 @@ test('test client credentials flow', async ({ page }) => {
     await runQueryAndCheckResults(page);
 });
 
-test('test client credentials flow with wrong credentials', async ({ page }) => {
-    await login(page);
-    await goToTrinoSettings(page);
-    await setupDataSourceWithClientCredentials(page, "some-wrong-client");
-    await expect(page.getByLabel(EXPORT_DATA)).toHaveCount(0);
-});
-
 test('test client credentials flow with configured access token', async ({ page }) => {
     await login(page);
     await goToTrinoSettings(page);
     await page.locator('div').filter({hasText: /^Access token$/}).locator('input[type="password"]').fill('aaa');
     await setupDataSourceWithClientCredentials(page, GRAFANA_CLIENT);
-    await expect(page.getByLabel(EXPORT_DATA)).toHaveCount(0);
+    await expect(page.getByTestId('data-testid Alert error')).toBeVisible();
+    await expect(page.getByTestId('data-testid Alert error')).toContainText('Internal Server Error');
 });
 
 test('test with client tags', async ({ page }) => {
@@ -97,7 +121,7 @@ test('test with roles', async ({ page }) => {
     await goToTrinoSettings(page);
     await setupDataSourceWithRoles(page, 'system:ALL;hive:admin');
     await runRoleQuery(page);
-    await expect(page.getByTestId('data-testid table body')).toContainText(/.*admin.*/);
+    await expect(page.locator('[role="table"][aria-label="Explore Table"]').getByText(/.*admin.*/).first()).toBeVisible();
 
 });
 
@@ -108,23 +132,3 @@ test('test without role', async ({ page }) => {
     await runRoleQuery(page);
     await expect(page.getByText(/Access Denied: Cannot show roles/)).toBeVisible();
 });
-
-async function setupDataSourceWithRoles(page: Page, roles: string) {
-    await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://trino:8080');
-    await page.locator('div').filter({hasText: /^Roles$/}).locator('input').fill(roles);
-    await page.getByTestId('data-testid Data source settings page Save and Test button').click();
-}
-
-async function runRoleQuery(page: Page) {
-    await page.getByLabel(EXPORT_DATA).click();
-    await page.locator('div').filter({hasText: /^Format asChoose$/}).locator('svg').click();
-    await page.getByRole('option', {name: 'Table'}).click();
-    await setQuery(page, 'SHOW ROLES FROM hive')
-    await page.getByTestId('data-testid Code editor container').click();
-    await page.getByTestId('data-testid RefreshPicker run button').click();
-}
-
-async function setQuery(page: Page, query: string) {
-    await page.getByTestId('data-testid Code editor container').click({ clickCount: 4 });
-    await page.keyboard.type(query);
-}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -51,7 +51,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=8.3.0",
+    "grafanaDependency": ">=9.5.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Run end-to-end tests against two Grafana versions in CI and ensure Grafana is fully ready before testing

Supersedes #321 and #303 