### PR TITLE
Prepare Grafana plugin 1.1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,11 @@ jobs:
         uses: grafana/plugin-actions/e2e-version@e2e-version/v3.0.2
         with:
           # Resolves against plugin.json's dependencies.grafanaDependency
-          # (>=13.1.0): the latest patch of every minor satisfying that
-          # range, plus nightly. Versions below our declared floor are
-          # intentionally excluded - we already know they're unsupported.
+          # (>=10.4.0): the latest patch of every minor satisfying that
+          # range. Nightly is intentionally excluded because its unstable UI
+          # is outside our supported Grafana versions.
           version-resolver-type: plugin-grafana-dependency
+          skip-grafana-nightly-image: true
 
   e2e:
     name: e2e ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Sign plugin
         run: yarn sign
         env:
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
+          # Requires the plugins:write scope.
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
 
       - name: Get plugin metadata
         id: metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0
+
+* Add support for Trino roles
+* Add support for client tags
+* Keep OAuth2 tokens isolated between data source instances
+* Respect configured CA certificates for Trino TLS connections
+* Modernize the Grafana plugin SDK and tooling and require Grafana 10.4 or later
+
 ## 1.0.12
 
 * Add support for OAuth2 client-credentials flow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trino-datasource",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "The Trino datasource allows to query and visualize Trino data from within Grafana.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Why
- The Grafana catalog is missing the accumulated roles, client tags, authentication, and TLS improvements since 1.0.12.
- Current plugin signing uses an access policy token; retaining the legacy API key risks producing an unsigned release.
- Grafana nightly changed its variable editor UI and broke the E2E lane, while every supported stable Grafana version passed.

## Approach
- Prepare version 1.1.0 and document its user-visible changes.
- Authenticate signing with the scoped GRAFANA_ACCESS_POLICY_TOKEN secret.
- Exclude nightly through the version resolver while retaining stable-version E2E coverage.

## Validation
- yarn build
- yarn lint
- yarn typecheck
- go test ./...
- mage -v
- The main CI build job, including Jest, passed in run 31571893495.