### PR TITLE
Add PDC support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,43 @@ jobs:
           echo "Preconfiguring trino..."
           docker exec trino trino --user admin --execute "GRANT admin TO USER grafana IN hive;"
 
+          # A second, isolated Trino instance reachable only through the
+          # secure SOCKS proxy below, used to prove Private Data Source
+          # Connect (PDC) support actually routes traffic through the proxy
+          # rather than just accepting the setting: the "trino" network
+          # (where Grafana lives) has no route to "trino-pdc-private", so a
+          # query can only succeed if it truly went through the proxy, which
+          # is dual-homed onto both networks. See DEVELOPMENT.md for how to
+          # reproduce this locally.
+          docker network create trino-pdc-private
+
+          echo "Starting trino-private (PDC-only network)..."
+          docker run --rm --detach \
+            --name trino-private \
+            --net trino-pdc-private \
+            --volume "$(pwd)/test-data/trino/test-trino-config-pdc.properties:/etc/trino/config.properties" \
+            --volume "$(pwd)/test-data/trino/catalog/hive.properties:/etc/trino/catalog/hive.properties" \
+            trinodb/trino:483
+
+          echo "Starting the SOCKS proxy (dual-homed)..."
+          docker run --rm --detach \
+            --name socks-proxy \
+            --net trino \
+            --env REQUIRE_AUTH=false \
+            serjs/go-socks5-proxy:v0.0.4
+          docker network connect trino-pdc-private socks-proxy
+
+          echo "Waiting for trino-private to be ready..."
+          while true; do
+            if docker logs trino-private 2>&1 | grep -q '======== SERVER STARTED ========'; then
+              echo "trino-private is ready!"
+              break
+            fi
+            echo "Waiting for trino-private..."
+            sleep 5
+          done
+          docker exec trino-private trino --user admin --execute "GRANT admin TO USER grafana IN hive;"
+
           echo "Starting Grafana grafana/${{ matrix.GRAFANA_IMAGE.name }}:${{ matrix.GRAFANA_IMAGE.version }}..."
           docker run --rm --detach \
             --name grafana \
@@ -191,6 +228,9 @@ jobs:
             --publish 3000:3000 \
             --volume "$(pwd)/dist:/var/lib/grafana/plugins/trino" \
             --env "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=trino-datasource" \
+            --env "GF_SECURE_SOCKS_DATASOURCE_PROXY_ENABLED=true" \
+            --env "GF_SECURE_SOCKS_DATASOURCE_PROXY_PROXY_ADDRESS=socks-proxy:1080" \
+            --env "GF_SECURE_SOCKS_DATASOURCE_PROXY_ALLOW_INSECURE=true" \
             "grafana/${{ matrix.GRAFANA_IMAGE.name }}:${{ matrix.GRAFANA_IMAGE.version }}"
           echo "Done."
 
@@ -200,6 +240,11 @@ jobs:
           url: http://localhost:3000/login
 
       - name: End to end test
+        env:
+          # Opts the PDC tests in - they need the trino-private/socks-proxy
+          # containers started above, so they're skipped when unset (e.g. for
+          # a plain local `yarn server` stack). See DEVELOPMENT.md.
+          PDC_PRIVATE_TRINO_URL: http://trino-private:8080
         run: |
           npx playwright install --with-deps chromium
           npx playwright test

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,6 +77,35 @@ provisioning expansion:
 Restart the stack to pick up changes; Grafana re-reads provisioning files on
 boot.
 
+## Secure SOCKS proxy (PDC)
+
+The dev stack always enables Grafana's secure SOCKS datasource proxy, so the
+"Secure Socks Proxy" toggle shows up in the datasource settings. To actually
+exercise it — the setup the `secure socks proxy (PDC)` e2e tests need — bring
+the stack up with the `pdc` profile:
+
+```bash
+yarn build && mage -v
+docker compose --profile pdc up --build
+```
+
+That adds two containers: `trino-private`, a second Trino instance on an
+isolated `pdc-private` network with no route to/from the network Grafana runs
+on, and `socks-proxy`, dual-homed onto both. `trino-private` is therefore
+reachable *only* through the proxy, so a query against it succeeding proves the
+toggle really routes traffic rather than just being accepted and ignored. The
+paired negative-control test checks the same host fails with the toggle off.
+
+Run the e2e suite against it with:
+
+```bash
+PDC_PRIVATE_TRINO_URL=http://trino-private:8080 yarn e2e
+```
+
+The two PDC tests are skipped when `PDC_PRIVATE_TRINO_URL` is unset, so a plain
+`yarn e2e` against a default `yarn server` stack is unaffected. CI sets it in
+the `End to end test` step.
+
 ## Verifier
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,12 @@
+# The `pdc-private` network deliberately has no route to/from the default
+# network Grafana lives on. Only `socks-proxy` is dual-homed, so the
+# `trino-private` instance below is reachable exclusively through the secure
+# SOCKS proxy - which is what makes the PDC e2e tests meaningful. See
+# DEVELOPMENT.md.
+networks:
+  default:
+  pdc-private:
+
 services:
   trino:
     image: trinodb/trino:483
@@ -6,6 +15,31 @@ services:
       interval: 5s
       timeout: 5s
       retries: 20
+
+  # Both of these only start under the `pdc` profile, i.e.
+  # `docker compose --profile pdc up --build`.
+  trino-private:
+    profiles: [pdc]
+    image: trinodb/trino:483
+    networks:
+      - pdc-private
+    volumes:
+      - ./test-data/trino/test-trino-config-pdc.properties:/etc/trino/config.properties
+      - ./test-data/trino/catalog/hive.properties:/etc/trino/catalog/hive.properties
+    healthcheck:
+      test: ["CMD", "/usr/lib/trino/bin/health-check"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  socks-proxy:
+    profiles: [pdc]
+    image: serjs/go-socks5-proxy:v0.0.4
+    networks:
+      - default
+      - pdc-private
+    environment:
+      REQUIRE_AUTH: "false"
 
   grafana:
     extends:
@@ -33,3 +67,11 @@ services:
       TRINO_CLIENT_ID: ${TRINO_CLIENT_ID:-}
       TRINO_CLIENT_SECRET: ${TRINO_CLIENT_SECRET:-}
       TRINO_TLS_SKIP_VERIFY: ${TRINO_TLS_SKIP_VERIFY:-false}
+
+      # --- Secure SOCKS proxy (PDC) ---
+      # Makes the "Secure Socks Proxy" toggle available in the datasource
+      # settings, pointed at the `socks-proxy` service above. The proxy only
+      # runs under the `pdc` profile; the toggle is simply a no-op otherwise.
+      GF_SECURE_SOCKS_DATASOURCE_PROXY_ENABLED: "true"
+      GF_SECURE_SOCKS_DATASOURCE_PROXY_PROXY_ADDRESS: socks-proxy:1080
+      GF_SECURE_SOCKS_DATASOURCE_PROXY_ALLOW_INSECURE: "true"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trinodb/grafana-trino
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.296.1

--- a/pkg/trino/driver/driver.go
+++ b/pkg/trino/driver/driver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	trinoClient "github.com/trinodb/grafana-trino/pkg/trino/client"
 
 	"github.com/trinodb/grafana-trino/pkg/trino/models"
@@ -35,11 +36,18 @@ func Open(settings models.TrinoDatasourceSettings) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
 	}
+	// Dial through Grafana's secure SOCKS proxy (used by Grafana Cloud's Private
+	// Data Source Connect) when the datasource has it enabled - ProxyOptions is
+	// set from jsonData.enableSecureSocksProxy, see SecureSocksProxyEnabledOnDS
+	// in the SDK - and a true no-op otherwise. Must happen before any wrapping
+	// below, so it applies regardless of which auth method is configured.
+	if err := proxy.New(settings.Opts.ProxyOptions).ConfigureSecureSocksHTTPProxy(transport); err != nil {
+		return nil, fmt.Errorf("failed to configure secure SOCKS proxy: %w", err)
+	}
+	client := &http.Client{Transport: transport}
 	if settings.TokenUrl != "" || settings.ClientId != "" || settings.ClientSecret != "" {
 		if settings.AccessToken != "" {
 			return nil, errors.New("access token must not be set within 'OAuth Trino Authentication' settings")

--- a/pkg/trino/driver/driver_test.go
+++ b/pkg/trino/driver/driver_test.go
@@ -9,11 +9,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 )
 
 func TestBuildTLSConfig(t *testing.T) {
@@ -165,6 +167,30 @@ func TestParseRoles(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecureSocksProxyDisabledIsNoop(t *testing.T) {
+	transport := &http.Transport{}
+
+	tests := []struct {
+		name string
+		opts *proxy.Options
+	}{
+		{name: "nil options", opts: nil},
+		{name: "explicitly disabled", opts: &proxy.Options{Enabled: false}},
+		{name: "enabled but no client config", opts: &proxy.Options{Enabled: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := proxy.New(tt.opts).ConfigureSecureSocksHTTPProxy(transport); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if transport.DialContext != nil {
+				t.Error("expected transport.DialContext to be left unset when the proxy is not enabled")
 			}
 		})
 	}

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent } from 'react';
 import { DataSourceHttpSettings, InlineField, InlineSwitch, SecretInput, Input } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { TrinoDataSourceOptions, TrinoSecureJsonData } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<TrinoDataSourceOptions, TrinoSecureJsonData> {}
@@ -45,6 +46,9 @@ export function ConfigEditor(props: Props) {
   };
   const onClientTagsChange = (event: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({ ...options, jsonData: { ...options.jsonData, clientTags: event.target.value } });
+  };
+  const onEnableSecureSocksProxyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, enableSecureSocksProxy: event.target.checked } });
   };
 
   return (
@@ -130,6 +134,27 @@ export function ConfigEditor(props: Props) {
           </InlineField>
         </div>
       </div>
+
+      {config.secureSocksDSProxyEnabled && (
+        <>
+          <h3 className="page-heading">Other Settings</h3>
+          <div className="gf-form-group">
+            <div className="gf-form-inline">
+              <InlineField
+                label="Secure Socks Proxy"
+                tooltip="Enable proxying the data source connection through the secure SOCKS proxy to a different network. Used by Grafana Cloud's Private Data Source Connect (PDC)."
+                labelWidth={26}
+              >
+                <InlineSwitch
+                  id="trino-settings-enable-secure-socks-proxy"
+                  value={options.jsonData?.enableSecureSocksProxy ?? false}
+                  onChange={onEnableSecureSocksProxyChange}
+                />
+              </InlineField>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -274,6 +274,11 @@ test('test template variable backed by trino query', async ({ page }) => {
     await login(page);
     await goToTrinoSettings(page);
     await setupDataSourceWithAccessToken(page);
+    // Wait for the save to land before navigating away - other tests get this
+    // for free by staying on the page to click "Explore data", but this one
+    // leaves immediately and would otherwise race the in-flight save, leaving
+    // a datasource with no URL for the variable query to use.
+    await expect(page.getByText('Data source is working')).toBeVisible({timeout: 15000});
 
     await page.goto('http://localhost:3000/dashboard/new?editview=templating&editIndex=0');
     await page.getByRole('tab', {name: 'Variables'}).click();
@@ -285,7 +290,9 @@ test('test template variable backed by trino query', async ({ page }) => {
     const takeMeThere = page.getByRole('button', {name: 'Take me there'});
     if (await takeMeThere.isVisible({timeout: 3000}).catch(() => false)) {
         await takeMeThere.click();
-        await page.getByTestId('data-testid edit pane add new variable button').click();
+        // Grafana 13.2 renamed this control's test id from "edit pane" to
+        // "sidebar"; accept either so both sides of that rename work.
+        await page.getByTestId(/data-testid (edit pane|sidebar) add new variable button/).click();
         await page.getByTestId('data-testid variable type query').click();
         await page.getByTestId('data-testid variable name input').fill('orderstatus');
         await page.getByText('Open variable editor').click();

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -85,7 +85,11 @@ async function runQueryAndCheckResults(page: Page) {
     await commitQuery(page);
     await selectFormat(page, 'Time Series', 'Table');
     await page.getByTestId('data-testid Code editor container').click();
-    await page.getByTestId('data-testid RefreshPicker run button').click();
+    const runButton = page.getByTestId('data-testid RefreshPicker run button');
+    // wait until any running queries have finished - the button is icon-only
+    // on newer Grafana, so aria-label is the only text carrying its state
+    await expect(runButton).toHaveAttribute('aria-label', /run/i, {timeout: 15000});
+    await runButton.click();
     await expect(page.getByRole('row', {name: /1995-01-\d\d .*:00:00 5703857 F/})).toBeVisible({timeout: 15000});
 }
 

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -125,6 +125,53 @@ test('test with client tags', async ({ page }) => {
     await runQueryAndCheckResults(page);
 });
 
+// PDC_PRIVATE_TRINO_URL points at a Trino instance reachable only through
+// the secure SOCKS proxy (no direct network route from Grafana). That proves
+// the proxy toggle actually routes traffic rather than just accepting the
+// setting, since a query can only succeed here if it truly went through the
+// proxy. It needs a Grafana with the secure SOCKS proxy configured plus the
+// isolated Trino and proxy containers, which the default `yarn server` stack
+// doesn't start - so these two tests are skipped unless the variable is set.
+// CI sets it, and DEVELOPMENT.md covers running them locally.
+const PDC_PRIVATE_TRINO_URL = process.env.PDC_PRIVATE_TRINO_URL;
+
+test.describe('secure socks proxy (PDC)', () => {
+    test.skip(!PDC_PRIVATE_TRINO_URL, 'PDC_PRIVATE_TRINO_URL is not set, see DEVELOPMENT.md');
+
+    test('test with secure socks proxy (PDC)', async ({ page }) => {
+        await login(page);
+        await goToTrinoSettings(page);
+        await page.getByTestId('data-testid Datasource HTTP settings url').fill(PDC_PRIVATE_TRINO_URL!);
+        await page.locator('label[for="trino-settings-enable-secure-socks-proxy"]').last().click();
+        await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+        await expect(page.getByText('Data source is working')).toBeVisible({timeout: 10000});
+        await runQueryAndCheckResults(page);
+    });
+
+    test('test without secure socks proxy cannot reach a PDC-only host', async ({ page }) => {
+        // Negative control: the same otherwise-unreachable host, without
+        // enabling the proxy toggle, must fail - proving the prior test's
+        // success is actually caused by the proxy and not some other route.
+        // Save & Test alone can't show this: trino-go-client doesn't implement
+        // database/sql's Pinger interface, so CheckHealth is a no-op regardless
+        // of reachability (see the "check health failure" test above). Only an
+        // actual query attempt forces a real connection.
+        await login(page);
+        await goToTrinoSettings(page);
+        await page.getByTestId('data-testid Datasource HTTP settings url').fill(PDC_PRIVATE_TRINO_URL!);
+        await page.getByTestId('data-testid Data source settings page Save and Test button').click();
+        await page.getByLabel(EXPORT_DATA).click();
+        await commitQuery(page);
+        // The Explore graph view renders a plain "No data" for a query error
+        // instead of visible error text - Table format surfaces it properly
+        // (same as the roles tests above).
+        await selectFormat(page, 'Time Series', 'Table');
+        await page.getByTestId('data-testid Code editor container').click();
+        await page.getByTestId('data-testid RefreshPicker run button').click();
+        await expect(page.getByText(/error querying the database/i)).toBeVisible({timeout: 15000});
+    });
+});
+
 test('test with roles', async ({ page }) => {
     await login(page);
     await goToTrinoSettings(page);
@@ -244,7 +291,7 @@ test('test template variable backed by trino query', async ({ page }) => {
         // query editor.
         await page.getByTestId('data-testid Variable editor Form Default Variable Query Editor textarea').fill('SELECT DISTINCT orderstatus FROM tpch.tiny.orders');
         await page.getByRole('button', {name: 'Run query'}).click();
-        await expect(page.getByText(/Preview of values/)).toBeVisible();
+        await expect(page.getByText(/Preview of values/)).toBeVisible({timeout: 10000});
         // The query editor opens in a modal dialog - scope to it since the
         // rest of the dashboard-builder page behind it also renders text.
         const dialog = page.getByRole('dialog');
@@ -259,7 +306,7 @@ test('test template variable backed by trino query', async ({ page }) => {
     await page.getByRole('textbox', {name: 'Metric name or tags query'}).fill('SELECT DISTINCT orderstatus FROM tpch.tiny.orders');
     await page.getByRole('button', {name: 'Run query'}).click();
     // Older Grafana versions don't show the "(N)" count suffix.
-    await expect(page.getByText(/Preview of values/)).toBeVisible();
+    await expect(page.getByText(/Preview of values/)).toBeVisible({timeout: 10000});
     // Older Grafana renders the preview as plain inline text tags; newer
     // versions render an actual sortable table. Scope to the variable
     // editor form and match loosely rather than assume either structure.

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface TrinoDataSourceOptions extends DataSourceJsonData {
   impersonationUser?: string;
   roles?: string;
   clientTags?: string;
+  enableSecureSocksProxy?: boolean;
 }
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend

--- a/test-data/trino/test-trino-config-pdc.properties
+++ b/test-data/trino/test-trino-config-pdc.properties
@@ -1,0 +1,5 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery.uri=http://localhost:8080
+catalog.management=static


### PR DESCRIPTION
Wires the secure SOCKS proxy (used by Grafana Cloud's Private Data Source Connect) into the Trino driver's HTTP transport, gated behind the datasource's jsonData.enableSecureSocksProxy - a true no-op when not enabled. Adds a matching ConfigEditor toggle, shown only when the host Grafana has the feature enabled (config.secureSocksDSProxyEnabled).

Adds real e2e coverage rather than just a unit test for the no-op path: the CI e2e job now also stands up a second, isolated Trino instance (trino-private) on a separate Docker network with no route from the main 'trino' network Grafana lives on, plus a dual-homed SOCKS proxy container (microsocks) bridging both networks. A query can only succeed against trino-private if it genuinely went through the proxy, which is what 'test with secure socks proxy (PDC)' asserts. A paired negative-control test confirms the same otherwise-unreachable host fails without the toggle enabled, proving the toggle is what makes the difference rather than some other route - CheckHealth alone can't show this, since trino-go-client doesn't implement database/sql's Pinger interface and is a no-op regardless of reachability.

Verified end-to-end (both the full existing suite and the two new PDC tests) against Grafana 10.4.19 (the plugin's current floor) and grafana-enterprise:nightly.

Closes: #312