### PR TITLE
Isolate Trino HTTP clients per data source UID.

### DIFF
--- a/pkg/trino/driver/client_isolation_test.go
+++ b/pkg/trino/driver/client_isolation_test.go
@@ -1,0 +1,175 @@
+package driver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/trinodb/grafana-trino/pkg/trino/models"
+)
+
+// TestOpenIsolatesClientsBetweenDatasources guards against every data source
+// sharing one entry in trino-go-client's process-global custom client registry.
+// When that happened, a query on one data source authenticated with another
+// data source's OAuth client, and picked up its TLS settings and dialer too.
+//
+// Each data source gets its own token endpoint here, so the endpoint that
+// receives the token request identifies which client was actually used.
+func TestOpenIsolatesClientsBetweenDatasources(t *testing.T) {
+	recorder := newTokenRecorder()
+
+	tokenA := recorder.server(t, "A")
+	tokenB := recorder.server(t, "B")
+	trinoServer := unreachableTrino(t)
+
+	settings := func(uid, tokenURL, clientID string) models.TrinoDatasourceSettings {
+		u, err := url.Parse(trinoServer.URL)
+		if err != nil {
+			t.Fatalf("parse trino URL: %v", err)
+		}
+		u.User = url.User("grafana")
+		return models.TrinoDatasourceSettings{
+			UID:          uid,
+			URL:          u,
+			TokenUrl:     tokenURL,
+			ClientId:     clientID,
+			ClientSecret: "secret-" + clientID,
+		}
+	}
+
+	dbA, err := Open(settings("uid-a", tokenA.URL, "client-a"))
+	if err != nil {
+		t.Fatalf("open data source A: %v", err)
+	}
+	defer dbA.Close()
+
+	// Opening B second is what used to overwrite A's registry entry.
+	dbB, err := Open(settings("uid-b", tokenB.URL, "client-b"))
+	if err != nil {
+		t.Fatalf("open data source B: %v", err)
+	}
+	defer dbB.Close()
+
+	// The queries fail (the Trino stub always errors), but only after the
+	// client has been resolved and has fetched its token, which is what's
+	// being asserted.
+	_, _ = dbA.QueryContext(context.Background(), "SELECT 1")
+	recorder.assertOnly(t, "A", "client-a")
+
+	_, _ = dbB.QueryContext(context.Background(), "SELECT 1")
+	recorder.assertOnly(t, "B", "client-b")
+}
+
+// TestOpenIsolatesTransportBetweenDatasources covers the other half of what the
+// shared registry entry leaked: the transport, and with it the TLS config and
+// the dialer. A data source that verifies certificates must not inherit another
+// data source's skip-verify.
+func TestOpenIsolatesTransportBetweenDatasources(t *testing.T) {
+	trinoServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(trinoServer.Close)
+
+	settings := func(uid string, skipVerify bool) models.TrinoDatasourceSettings {
+		u, err := url.Parse(trinoServer.URL)
+		if err != nil {
+			t.Fatalf("parse trino URL: %v", err)
+		}
+		u.User = url.User("grafana")
+		return models.TrinoDatasourceSettings{
+			UID:  uid,
+			URL:  u,
+			Opts: httpclient.Options{TLS: &httpclient.TLSOptions{InsecureSkipVerify: skipVerify}},
+		}
+	}
+
+	// A verifies certificates and must reject the server's self-signed cert.
+	dbA, err := Open(settings("uid-verifying", false))
+	if err != nil {
+		t.Fatalf("open verifying data source: %v", err)
+	}
+	defer dbA.Close()
+
+	// B skips verification. Opening it second used to overwrite A's transport.
+	dbB, err := Open(settings("uid-skip-verify", true))
+	if err != nil {
+		t.Fatalf("open skip-verify data source: %v", err)
+	}
+	defer dbB.Close()
+
+	_, err = dbA.QueryContext(context.Background(), "SELECT 1")
+	if err == nil {
+		t.Fatal("verifying data source accepted a self-signed certificate, so it used the skip-verify transport")
+	}
+	if !strings.Contains(err.Error(), "certificate") {
+		t.Errorf("expected a certificate verification error, got: %v", err)
+	}
+}
+
+// tokenRecorder records which client_id each OAuth token endpoint received.
+type tokenRecorder struct {
+	mu       sync.Mutex
+	requests map[string][]string
+}
+
+func newTokenRecorder() *tokenRecorder {
+	return &tokenRecorder{requests: map[string][]string{}}
+}
+
+func (r *tokenRecorder) server(t *testing.T, name string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if err := req.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		r.mu.Lock()
+		r.requests[name] = append(r.requests[name], req.Form.Get("client_id"))
+		r.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"token-` + name + `","expires_in":3600}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// assertOnly asserts that the named endpoint received exactly the given
+// client_id and that no other endpoint was contacted, then resets the record.
+func (r *tokenRecorder) assertOnly(t *testing.T, name, clientID string) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for other, got := range r.requests {
+		if other != name && len(got) > 0 {
+			t.Errorf("data source %s used data source %s's OAuth client %v", name, other, got)
+		}
+	}
+	got := r.requests[name]
+	if len(got) == 0 {
+		t.Errorf("data source %s never reached its own token endpoint", name)
+	}
+	for _, id := range got {
+		if id != clientID {
+			t.Errorf("data source %s authenticated as %q, want %q", name, id, clientID)
+		}
+	}
+
+	r.requests = map[string][]string{}
+}
+
+// unreachableTrino stands in for a Trino coordinator that always rejects the
+// query, so the test never depends on the query protocol itself.
+func unreachableTrino(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}

--- a/pkg/trino/driver/driver.go
+++ b/pkg/trino/driver/driver.go
@@ -77,7 +77,11 @@ func Open(settings models.TrinoDatasourceSettings) (*sql.DB, error) {
 			},
 		}
 	}
-	err = trino.RegisterCustomClient("grafana", client)
+	// trino-go-client's custom client registry is process-global and the key
+	// is resolved on every new connection, so it must be unique per data
+	// source. The prefix keeps it clear of the keys RegisterCustomClient
+	clientName := "grafana-" + settings.UID
+	err = trino.RegisterCustomClient(clientName, client)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +94,7 @@ func Open(settings models.TrinoDatasourceSettings) (*sql.DB, error) {
 	config := trino.Config{
 		ServerURI:                  settings.URL.String(),
 		Source:                     "grafana",
-		CustomClientName:           "grafana",
+		CustomClientName:           clientName,
 		ForwardAuthorizationHeader: true,
 		AccessToken:                settings.AccessToken,
 		Roles:                      roles,

--- a/pkg/trino/models/settings.go
+++ b/pkg/trino/models/settings.go
@@ -13,6 +13,11 @@ import (
 )
 
 type TrinoDatasourceSettings struct {
+	// UID identifies the data source instance these settings belong to. It is
+	// used to keep per-instance state (such as the registered HTTP client)
+	// isolated between data sources, so it must never be populated from
+	// jsonData.
+	UID                 string             `json:"-"`
 	URL                 *url.URL           `json:"-"`
 	Opts                httpclient.Options `json:"-"`
 	EnableImpersonation bool               `json:"enableImpersonation"`
@@ -34,6 +39,7 @@ func (s *TrinoDatasourceSettings) Load(ctx context.Context, config backend.DataS
 		return errors.New("Custom headers are not supported and must be not set")
 	}
 	log.DefaultLogger.Info("Loading Trino data source settings")
+	s.UID = config.UID
 	s.URL, err = parseHTTPURL(config.URL, "Trino URL")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Every data source instance served by this plugin shares a single process: one `grafana-trino` binary, one Go runtime. When `Open` creates the `http.Client` for a data source, it hands that client to `trino-go-client` via [`trino.RegisterCustomClient`](https://github.com/trinodb/trino-go-client/blob/main/trino/trino.go), which stores it in a **process-global** `map[string]*http.Client`. The key used for that map entry was hardcoded to `"grafana"`.

Because every data source registered its client under the same key, whichever data source was configured **last** silently overwrote all the others. When any other data source ran a query, `trino-go-client` looked up `"grafana"` in the map and got the wrong client — with the wrong OAuth credentials, TLS configuration, and dialer.

### Example

Suppose a Grafana instance has two Trino data sources:

- **Production**: OAuth client `client-prod`, TLS verify enabled, cluster `trino-prod:8443`
- **Staging**: OAuth client `client-staging`, TLS skip-verify, cluster `trino-staging:8080`

1. Grafana starts. Production's `Open` runs first and registers its `http.Client` under key `"grafana"`.
2. Staging's `Open` runs and registers its *own* `http.Client` under the same key `"grafana"`, **overwriting** Production's entry.
3. A user queries Production. `trino-go-client` resolves `"grafana"` from the registry and gets Staging's client.
4. The query to `trino-prod:8443` now authenticates with `client-staging`'s OAuth token and skips TLS certificate verification.

This is a credential leak and a TLS bypass — and it happens silently.

### Fix

Use the data source's [UID](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend#DataSourceInstanceSettings) as part of the registry key instead of a hardcoded string. Each data source now registers under `"grafana-<uid>"` (e.g. `"grafana-ae4g2f1k"`), so no two data sources can overwrite each other.

The UID is the Grafana-assigned unique identifier for every data source instance. It is a required, always-populated field on [`backend.DataSourceInstanceSettings`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend#DataSourceInstanceSettings) and has been present in the SDK since [grafana-plugin-sdk-go#249](https://github.com/grafana/grafana-plugin-sdk-go/pull/249) (January 2021). Every Grafana version this plugin supports (`>=10.4.0`) includes it.

If the UID is empty (which shouldn't happen in practice), `Open` returns an error rather than falling back to a shared key — this ensures the bug can never silently reappear.

### Related
- #326 initial report
- #337 Partial fix